### PR TITLE
金融クイズユースケース更新

### DIFF
--- a/docs/usecase.puml
+++ b/docs/usecase.puml
@@ -135,18 +135,34 @@ note right Developer
 end note
 
 == 継続学習（7日間） ==
-AI -> Mail : クイズ生成指示
+AI -> AI : 定期起動
+activate AI
+AI -> DB : ユーザー特性/学習状況の取得
+activate DB
+DB -> AI : 
+deactivate DB
+AI -> AI : クイズの生成
+AI -> DB : クイズ保存 
+activate DB
+DB -> AI : クイズID取得
+deactivate DB
+AI -> Mail : メール送信指示
+deactivate AI
 activate Mail
 Mail -> User : 1日3問クイズ配信
 deactivate Mail
 activate User
-User -> Backend : 回答
+User -> UI : リンククリック
 deactivate User
+activate UI
+UI -> Backend : クイズ回答連携
+deactivate UI
 activate Backend
 Backend -> AI : 回答連携
 deactivate Backend
 activate AI
 AI -> AI : 弱点分析
+AI -> DB : 学習状況更新
 deactivate AI
 
 


### PR DESCRIPTION
システム側の設計を一部反映しました！

## 金融クイズユースケース更新

以下の内容を更新しました
- 回答をWebUI上からに変更　
  - メールクライアントからスクリプトは不可。
  - （aタグでの制御も可能だが認証など検討事項が多めなので避けたい）
- クイズユースケースにおけるDBへのアクセスを明示

@ayakaki 
ユースケースにTODO詳細のアップデートとあったので反映しちゃいましたがもしやり方違えば教えてください～

issue:https://github.com/users/hidaken991018/projects/5/views/1?pane=issue&itemId=146297456&issue=hidaken991018%7CAgentic-AI-Hackathon-Team-Brave%7C35