### PR TITLE
 AIエージェントからDBへの書き込み禁止

### DIFF
--- a/docs/hearing-sequence.puml
+++ b/docs/hearing-sequence.puml
@@ -18,6 +18,7 @@ note over Backend, DB
   ・追加質問: 最大3回まで
   ・エラー時: 自動リトライ（最大2回）後にエラー返却
   ・データ保存: ヒアリングJSON + ユーザー特性をDBに永続化
+  ・DBへのWrite: Backendのみが実行（Agentは読み取り専用）
 end note
 
 == 新規セッション開始 ==
@@ -29,7 +30,7 @@ activate Sessions
 Sessions --> Agent : session_id, 初期状態
 deactivate Sessions
 
-note over Agent, DB : Tool: fetch_user_profile
+note over Agent, DB : Tool: fetch_user_profile (Read Only)
 Agent -> DB : 既存ユーザー特性取得
 DB --> Agent : user_profile（存在すれば）
 
@@ -139,13 +140,20 @@ activate LLM
 LLM --> Agent : ヒアリングJSON
 deactivate LLM
 
-note over Agent, DB : Tool: save_hearing_json
-Agent -> DB : ヒアリングJSON保存
-DB --> Agent : 保存完了
+Agent -> Sessions : セッション状態更新\n(ヒアリングJSON保存)
 
-note over Agent, DB : Tool: save_user_profile
-Agent -> DB : ユーザー特性保存/更新
-DB --> Agent : 保存完了
+Agent --> Backend : ヒアリングJSON, ユーザー特性
+deactivate Agent
+
+note over Backend, DB
+  BackendがDBへの書き込みを実行
+end note
+activate Backend
+Backend -> DB : ヒアリングJSON保存
+DB --> Backend : 保存完了
+Backend -> DB : ユーザー特性保存/更新
+DB --> Backend : 保存完了
+deactivate Backend
 
 note right DB
   【ヒアリングJSON】
@@ -157,11 +165,6 @@ note right DB
   （リスク許容度、計画志向、優先軸等）
   ※次回ヒアリング時に再利用
 end note
-
-Agent -> Sessions : セッション状態更新
-
-Agent --> Backend : ヒアリングJSON
-deactivate Agent
 
 == ライフプラン表受信〜結果生成・永続化 ==
 Backend -> Agent : ライフプラン表送信・生成要求(session_id, ライフプランJSON TB)
@@ -228,17 +231,18 @@ end note
 LLM --> Agent : チェックリストJSON
 deactivate LLM
 
-Agent -> Sessions : セッション状態更新\n(checklist保存)
-
-' --- 永続化 ---
-note over Agent, DB : Tool: save_life_plan_result
-Agent -> DB : ライフプラン結果保存\n(ライフイベント, コメント, チェックリスト)
-DB --> Agent : 保存完了
-
-Agent -> Sessions : セッション状態更新\n(status: completed)
+Agent -> Sessions : セッション状態更新\n(checklist保存, status: completed)
 
 Agent --> Backend : 生成結果\n(ライフイベント, コメント, チェックリスト)
 deactivate Agent
+
+note over Backend, DB
+  BackendがDBへの書き込みを実行
+end note
+activate Backend
+Backend -> DB : ライフプラン結果保存\n(ライフイベント, コメント, チェックリスト)
+DB --> Backend : 保存完了
+deactivate Backend
 
 
 == エラーハンドリング（共通） ==
@@ -248,10 +252,10 @@ note over Agent, LLM
   2. それでも失敗 → Backend にエラー返却
 end note
 
-note over Agent, DB
-  【DB保存失敗時】
+note over Backend, DB
+  【DB保存失敗時（Backend側で発生）】
   1. 自動リトライ（最大2回）
-  2. それでも失敗 → Backend にエラー返却
+  2. それでも失敗 → エラーレスポンス返却
   ※ Sessions の状態は保持されるため再試行可能
 end note
 


### PR DESCRIPTION
AIエージェントからDBへの書き込み禁止してバックエンドから書き込むように変更
###DB操作の使い分け
Write権限を持たせる基準を整理
- アプリ側：事前にDB操作の有無が決まっているケース
- AIエージェント：AIにDB操作の有無から判断をしてほしいケース

<img width="658" height="2212" alt="image" src="https://github.com/user-attachments/assets/eb703f5b-35e8-40ce-87ad-8b4b45b20337" />