### PR TITLE
feat: 基本画面のURL設計と簡易実装

### DIFF
--- a/app/src/app/compass/page.tsx
+++ b/app/src/app/compass/page.tsx
@@ -1,0 +1,7 @@
+export default function Compass() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">Life Compass表示画面です</h1>
+    </div>
+  );
+}

--- a/app/src/app/hearing/page.tsx
+++ b/app/src/app/hearing/page.tsx
@@ -1,0 +1,7 @@
+export default function Hearing() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">ヒアリング画面です</h1>
+    </div>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,65 +1,7 @@
-import Image from "next/image";
-
-export default function Home() {
+export default function Dashboard() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between bg-white px-16 py-32 sm:items-start dark:bg-black">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl leading-10 font-semibold tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="bg-foreground text-background flex h-12 w-full items-center justify-center gap-2 rounded-full px-5 transition-colors hover:bg-[#383838] md:w-[158px] dark:hover:bg-[#ccc]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] md:w-[158px] dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+    <div className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">履歴ダッシュボード画面です</h1>
     </div>
   );
 }

--- a/app/src/app/quiz/page.tsx
+++ b/app/src/app/quiz/page.tsx
@@ -1,0 +1,7 @@
+export default function Quiz() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-bold">クイズ画面です</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 対応Issue
- 画面遷移図に基づく基本画面の作成

## 🚀 実装内容
- 履歴ダッシュボード画面（`/`）を実装
- ヒアリング画面（`/hearing`）を実装
- Life Compass表示画面（`/compass`）を実装
- クイズ画面（`/quiz`）を実装

各画面は「○○画面です」と表示するシンプルな実装で、今後の機能実装の基盤となります。

## 🧪 動作確認
- [x] ビルドが成功すること（`npm run build`）
- [x] 各URLで画面が表示されること
  - http://localhost:3000/
  - http://localhost:3000/hearing
  - http://localhost:3000/compass
  - http://localhost:3000/quiz

## ➕ 備考
- Next.js App Routerの仕様に従った構造
- [画面遷移図](https://github.com/hidaken991018/Agentic-AI-Hackathon-Team-Brave/wiki/%E7%94%BB%E9%9D%A2%E9%81%B7%E7%A7%BB%E5%9B%B3)に基づいたURL設計
- モーダルは除外（今回は画面のみ実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)