### PR TITLE
セッション情報追加用APIエンドポイントを追加

### DIFF
--- a/app/src/app/api/agents/add-info/route.ts
+++ b/app/src/app/api/agents/add-info/route.ts
@@ -1,0 +1,56 @@
+// app/api/agents/add-info/route.ts
+export const runtime = "nodejs";
+
+import { fpInstructor } from "@/agents/fpInstructor";
+import { createSessionId } from "@/libs/google/createSessionId";
+import { getAccessToken } from "@/libs/google/getAccessToken";
+
+type Body = {
+  userId: string;
+  usedSessionId: string | undefined;
+  userMessage: string;
+};
+
+export async function POST(req: Request) {
+  const { userId, usedSessionId, userMessage } = (await req.json()) as Body;
+
+  console.log("Received request to add session info", userMessage);
+
+  // === アクセストークン取得 ===
+  const accessToken = await getAccessToken();
+
+  // === セッションの取得 ===
+  const sessionId = usedSessionId
+    ? usedSessionId
+    : await createSessionId(userId);
+
+  // === FP AI によるセッション情報の追加 ===
+  const requestToAi = `ユーザーから以下の情報を受け取りました。セッションにこの情報を記録してください。
+    ユーザーのコメントは次のとおりです。`;
+
+  const fpAiStart = Date.now();
+  await fpInstructor(
+    accessToken,
+    userId,
+    sessionId,
+    requestToAi,
+    userMessage,
+  );
+  console.log("==============================");
+  console.log(`FP AI の処理完了（process time: ${Date.now() - fpAiStart}）`);
+  console.log("セッションに情報を追加しました");
+  console.log("==============================");
+
+  // === シンプルなレスポンス（アウトプットは求めない） ===
+  return new Response(
+    JSON.stringify({
+      success: true,
+      userId,
+      sessionId,
+      message: "セッションに情報を追加しました"
+    }),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}


### PR DESCRIPTION
## 📝 対応Issue
<!-- 対応したIssueの番号を記載してください -->
- #

## 🚀 実装内容
<!-- PRの修正内容 -->
- `/api/agents/add-info`エンドポイントを追加
- FP Instructorエージェントを呼び出し、セッションに情報を追加する機能を実装
- アウトプットは返さず、セッション情報の追加のみを行う
- `agent/query`を参考に実装
- アクセストークン取得とセッション管理機能を含む
- シンプルな成功レスポンス（200 OK）を返す

## 🧪 動作確認
<!-- ローカル動作確認内容 -->
- [ ] ローカルで開発サーバーを起動し、エンドポイントが正常に動作することを確認
- [ ] FP Instructorエージェントが正常に呼び出されることを確認
- [ ] セッション情報が適切に追加されることを確認
- [ ] エラーハンドリングが適切に機能することを確認

## 📸 キャプチャ
<!-- UI変更時など必要な時のみ記載-->
- API実装のためキャプチャなし

## ➕ 備考
<!-- その他記載したいこと -->
- このエンドポイントは情報追加専用で、JSONレスポンスの生成は行いません
- 既存の`/api/agent/query`エンドポイントとの主な違いは、JSONエディターエージェントを呼び出さない点です