### PR TITLE
fix: NEXT_PUBLIC_APP_URL を APP_URL にリネームし Secret Manager で管理

### DIFF
--- a/app/src/middleware/authMiddleware.ts
+++ b/app/src/middleware/authMiddleware.ts
@@ -17,7 +17,7 @@ import { getAdminAuth } from "@/libs/firebase/admin";
  * CORS 許可オリジン設定
  */
 const ALLOWED_ORIGINS = [
-  process.env.NEXT_PUBLIC_APP_URL,
+  process.env.APP_URL,
   "http://localhost:3000",
   "http://localhost:3001",
 ].filter(Boolean) as string[];

--- a/cloud/cloudRun.tf
+++ b/cloud/cloudRun.tf
@@ -39,6 +39,17 @@ resource "google_cloud_run_v2_service" "front_back_app" {
           }
         }
       }
+
+      # アプリケーションURL（CORS許可オリジン用、Secret Managerから取得）
+      env {
+        name = "APP_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.secrets["APP_URL"].secret_id
+            version = "latest"
+          }
+        }
+      }
     }
   }
 

--- a/cloud/secretManager.tf
+++ b/cloud/secretManager.tf
@@ -19,6 +19,7 @@ locals {
     "ENV_VAR_TEST_2"        = "default-value-2"
     "DATABASE_URL"          = "postgresql://user:password@host:5432/dbname" # GCPコンソールで実際の値に更新
     "FIRESTORE_DATABASE_ID" = "life-compass"
+    "APP_URL"               = "https://example.com" # GCPコンソールで実際の値に更新
   }
 }
 


### PR DESCRIPTION
他のエラーもありライフコンパス表示までには至りませんが一旦CORS解消しております。

## 📝 対応Issue
- CORS許可オリジン用環境変数の命名修正と適切な管理

## 🚀 実装内容
- `authMiddleware.ts`: `process.env.NEXT_PUBLIC_APP_URL` → `process.env.APP_URL` にリネーム
- `cloud/secretManager.tf`: `APP_URL` シークレットを追加（デフォルト値付き）
- `cloud/cloudRun.tf`: Cloud Run env に `APP_URL` を Secret Manager 参照で追加

### 実装方針: `getEnv()` を使用しない理由

プロジェクトでは `getEnv()` による Secret Manager API 直接取得パターンも存在しますが、今回は Cloud Run env 注入 + `process.env` 方式を採用しました。

- `APP_URL` は CORS 許可オリジンとしてモジュールレベル定数で定義されており、`getEnv()` を使う場合は async 化が必要
- async 化の波及範囲が広い（`isOriginAllowed`, `addCorsHeaders`, `handlePreflight` + 呼び出し元の route handler 4ファイル）ため、**非同期処理を実装するコストが高い**
- `FIRESTORE_DATABASE_ID` と同じ Cloud Run env 注入パターンに従い、一貫性を維持

## 🧪 動作確認
- [x] `npm run build` でビルド成功を確認

## 📸 キャプチャ
- 対応前
![image](https://github.com/user-attachments/assets/78526674-3227-4191-8627-0b387f4a4153)

- 対応後
![image](https://github.com/user-attachments/assets/edc7f243-b6f5-4d86-b937-d24afb5dd3aa)

## ➕ 備考
- `APP_URL` の実際の値は GCP コンソールの Secret Manager で設定が必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)