### PR TITLE
fix: ヒアリングページの質問文修正と不要要素の削除

### DIFF
--- a/app/src/components/hearingForm/StepBar.tsx
+++ b/app/src/components/hearingForm/StepBar.tsx
@@ -27,22 +27,20 @@ export function StepBar({ currentStep, steps }: StepBarProps) {
             >
               {/* ステップの丸印 */}
               <div
-                className={`flex h-8 w-8 items-center justify-center rounded-full border-2 transition-colors duration-300 ${
-                  isCompleted
+                className={`flex h-8 w-8 items-center justify-center rounded-full border-2 transition-colors duration-300 ${isCompleted
                     ? "bg-primary border-primary text-primary-foreground"
                     : isActive
                       ? "border-primary text-primary font-bold"
                       : "bg-background border-muted text-muted-foreground"
-                }`}
+                  }`}
               >
                 {isCompleted ? <Check className="h-5 w-5" /> : index + 1}
               </div>
 
               {/* ステップ名（デスクトップ向け） */}
               <span
-                className={`mt-2 text-xs font-medium transition-colors md:text-sm ${
-                  isActive ? "text-primary" : "text-muted-foreground"
-                }`}
+                className={`mt-2 text-xs font-medium transition-colors md:text-sm ${isActive ? "text-primary" : "text-muted-foreground"
+                  }`}
               >
                 {step.stepTitle}
               </span>
@@ -60,9 +58,6 @@ export function StepBar({ currentStep, steps }: StepBarProps) {
           value={progressValue}
           className="h-2 transition-all duration-500"
         />
-        <p className="text-muted-foreground mt-1 text-right text-[10px]">
-          全体完了率: {Math.round(progressValue)}%
-        </p>
       </div>
     </div>
   );

--- a/app/src/consts/questions.ts
+++ b/app/src/consts/questions.ts
@@ -4,13 +4,6 @@ export const QUESTIONS = [
     stepTitle: "基本情報",
     questions: [
       {
-        id: "q01",
-        label: "あなたの名前を教えてください。",
-        type: "text",
-        required: true,
-        mapping: "basicProfile.user.name",
-      },
-      {
         id: "q02",
         label: "あなたの誕生年を教えてください。",
         type: "select",
@@ -119,7 +112,7 @@ export const QUESTIONS = [
     questions: [
       {
         id: "q14",
-        label: "数字はAIに自動算出させますか？",
+        label: "物価上昇率や収入成長率を自動算出しますか？",
         type: "radio",
         options: [
           { label: "はい", value: "yes" },
@@ -191,7 +184,7 @@ export const QUESTIONS = [
         fields: [
           {
             id: "q21",
-            label: "納める金額(月額)",
+            label: "家庭に納める金額(月額)",
             type: "number",
             required: true,
             mapping: "initialAmount",
@@ -254,7 +247,7 @@ export const QUESTIONS = [
         fields: [
           {
             id: "q30",
-            label: "納める金額(月額)",
+            label: "家庭に納める金額(月額)",
             type: "number",
             mapping: "initialAmount",
           },
@@ -584,7 +577,12 @@ export const QUESTIONS = [
     step: 6,
     stepTitle: "価値観",
     questions: [
-      { id: "q73", label: "資産目標額", type: "number", required: true },
+      {
+        id: "q73",
+        label: "65歳時点（公的年金開始年齢）までの資産目標額",
+        type: "number",
+        required: true,
+      },
       {
         id: "q74",
         label: "FPのコメントスタンス",


### PR DESCRIPTION
## 📝 対応Issue
- https://github.com/hidaken991018/Agentic-AI-Hackathon-Team-Brave/issues/176
## 🚀 実装内容
- 名前入力の質問(q01)を削除
- 質問ラベルをより具体的な表現に修正
  - 「数字はAIに自動算出させますか？」→「物価上昇率や収入成長率を自動算出しますか？」
  - 「納める金額(月額)」→「家庭に納める金額(月額)」（2箇所）
  - 「資産目標額」→「65歳時点（公的年金開始年齢）までの資産目標額」
- StepBarから全体完了率の表示を削除
- StepBarのコードフォーマット調整

## 🧪 動作確認
- [ ] ヒアリングページが正常に表示されること
- [ ] StepBarが正しく動作すること

## 📸 キャプチャ
### No.1　ステップ進捗削除
<img width="785" height="139" alt="image" src="https://github.com/user-attachments/assets/4127904e-f665-42ce-8014-7736bea2704f" />

### No.2　姓名削除
<img width="784" height="765" alt="image" src="https://github.com/user-attachments/assets/442aca36-ab6d-4b95-ae8f-7f70f6ea5536" />

### No.3 文言変更
旧：AIに自動算出させますか
新：物価上昇率や収入成長率を自動算出しますか
<img width="772" height="283" alt="image" src="https://github.com/user-attachments/assets/d4c11eb5-91ae-40c7-9803-d08d3a878acb" />


### No.4 文言変更
旧：資産目標額
新：65歳時点（公的年金開始年齢）の資産目標額
<img width="759" height="122" alt="image" src="https://github.com/user-attachments/assets/82e84f8b-2988-46df-bf33-7ecf7958edc4" />

### No.5
旧：納める金額
新：家庭に納める金額
<img width="674" height="154" alt="image" src="https://github.com/user-attachments/assets/002684ad-bb80-4481-b64c-b6d4ff60b74a" />




## ➕ 備考
-

🤖 Generated with [Claude Code](https://claude.com/claude-code)