### PR TITLE
fix: ESLint warning 21件を解消（lifePlan除く）

### DIFF
--- a/app/src/app/api/agent/query/route.ts
+++ b/app/src/app/api/agent/query/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
     : await createSessionId(userId);
 
   // === FP AI によるJson更新指示の生成 ===
-   const promptInstructToJsonEditor = `ライフプランデータを分析し、以下のルールに従って各項目を作成してください。
+  const promptInstructToJsonEditor = `ライフプランデータを分析し、以下のルールに従って各項目を作成してください。
 
   ### 各項目の作成ルール
   1. commentList:
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
     - 記述形式：「ユーザーは〇〇年頃に△△という状況になるため、☆☆に関する知識を問うクイズを出題し、□□の意識を高める方針とする」といった戦略的な内容にしてください。
     - 改行は \n にエスケープし、1つの連続した文字列として格納してください。`;
 
-  const aijsonResponse = await jsonEditor(aiCommentJsonSchemaForLlm, promptInstructToJsonEditor);
+  await jsonEditor(aiCommentJsonSchemaForLlm, promptInstructToJsonEditor);
 
   const fpAiInstructionStart = Date.now();
   const instructions = await fpInstructor(

--- a/app/src/app/hearing/_components/domain/hooks/useAdditionalQuestions.ts
+++ b/app/src/app/hearing/_components/domain/hooks/useAdditionalQuestions.ts
@@ -51,7 +51,7 @@ export interface UseAdditionalQuestionsReturn {
  * });
  */
 export function useAdditionalQuestions(
-  options: UseAdditionalQuestionsOptions
+  options: UseAdditionalQuestionsOptions,
 ): UseAdditionalQuestionsReturn {
   const { sessionId, user, initialQuestionCount = 0 } = options;
   const router = useRouter();
@@ -82,10 +82,12 @@ export function useAdditionalQuestions(
         setQuestions(data.questions);
         setQuestionCount(data.questionCount);
         console.log(
-          `[useAdditionalQuestions] Loaded ${data.questions.length} questions (round ${data.questionCount})`
+          `[useAdditionalQuestions] Loaded ${data.questions.length} questions (round ${data.questionCount})`,
         );
       } else if (data.status === "hearing_completed") {
-        console.log("[useAdditionalQuestions] Hearing completed, redirecting...");
+        console.log(
+          "[useAdditionalQuestions] Hearing completed, redirecting...",
+        );
         router.push(`/life-compass?sessionId=${sessionId}`);
       }
     } catch (err) {
@@ -102,7 +104,9 @@ export function useAdditionalQuestions(
     if (!sessionId || !user) return;
 
     // 初回マウント時のみ実行
-    console.log("[useAdditionalQuestions] Fetching questions (initial mount)...");
+    console.log(
+      "[useAdditionalQuestions] Fetching questions (initial mount)...",
+    );
     setLoading(true);
     setError(null);
     setContextError(null);
@@ -117,24 +121,29 @@ export function useAdditionalQuestions(
           setQuestions(data.questions);
           setQuestionCount(data.questionCount);
           console.log(
-            `[useAdditionalQuestions] Loaded ${data.questions.length} questions (round ${data.questionCount})`
+            `[useAdditionalQuestions] Loaded ${data.questions.length} questions (round ${data.questionCount})`,
           );
         } else if (data.status === "hearing_completed") {
-          console.log("[useAdditionalQuestions] Hearing completed, redirecting...");
+          console.log(
+            "[useAdditionalQuestions] Hearing completed, redirecting...",
+          );
           router.push(`/life-compass?sessionId=${sessionId}`);
         }
       })
       .catch((err) => {
         const errorMessage = "追加質問の取得に失敗しました。";
-        console.error("[useAdditionalQuestions] Error fetching questions:", err);
+        console.error(
+          "[useAdditionalQuestions] Error fetching questions:",
+          err,
+        );
         setError(errorMessage);
         setContextError(errorMessage);
       })
       .finally(() => {
         setLoading(false);
       });
-  }, [sessionId, user]); // sessionIdとuserのみ依存
-  // questionCountは依存配列に含めない(初回値のみ使用)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, user]); // sessionIdとuserのみ依存（初回マウント時のみ実行）
 
   return {
     questions,

--- a/app/src/app/hearing/additional-questions/page.tsx
+++ b/app/src/app/hearing/additional-questions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 
 import { AdditionalQuestionField } from "@/components/hearingForm/AdditionalQuestionField";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -69,7 +69,7 @@ export default function AdditionalQuestionsPage() {
   });
 
   // 全回答が空かどうかを監視（ボタンラベルの動的切り替え用）
-  const watchedValues = form.watch();
+  const watchedValues = useWatch({ control: form.control });
   const allEmpty = isAllAnswersEmpty(watchedValues);
 
   // エラーを統合

--- a/app/src/libs/devUtils/autoFill/autoFillEngine.ts
+++ b/app/src/libs/devUtils/autoFill/autoFillEngine.ts
@@ -4,7 +4,7 @@
  */
 
 import _ from "lodash";
-import { UseFormReturn } from "react-hook-form";
+import { FieldValues, UseFormReturn } from "react-hook-form";
 
 import { FlexibleQuestion, StepData } from "@/schema/hearingFormSchema";
 
@@ -24,7 +24,7 @@ export class AutoFillEngine {
    */
   fillForm(
     steps: readonly StepData[],
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     options: FillOptions = {},
   ): void {
     const personaData = this.getPersonaData(options.persona);
@@ -51,7 +51,7 @@ export class AutoFillEngine {
    */
   fillStep(
     step: StepData,
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     options: FillOptions = {},
   ): void {
     const personaData = this.getPersonaData(options.persona);
@@ -88,7 +88,7 @@ export class AutoFillEngine {
    */
   private fillUnconditionalFields(
     steps: readonly StepData[],
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     personaData: PersonaData,
   ): void {
     steps.forEach((step) => {
@@ -106,7 +106,7 @@ export class AutoFillEngine {
    */
   private fillConditionalFields(
     steps: readonly StepData[],
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     personaData: PersonaData,
   ): void {
     steps.forEach((step) => {
@@ -130,7 +130,7 @@ export class AutoFillEngine {
    */
   private fillQuestion(
     question: FlexibleQuestion,
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     personaData: PersonaData,
   ): void {
     if (question.type === "field_array") {
@@ -157,10 +157,13 @@ export class AutoFillEngine {
    */
   private fillFieldArrayQuestion(
     question: FlexibleQuestion,
-    form: UseFormReturn<any>,
+    form: UseFormReturn,
     personaData: PersonaData,
   ): void {
-    const arrayData = this.filler.fillField(question, personaData) as any[];
+    const arrayData = this.filler.fillField(question, personaData) as Record<
+      string,
+      unknown
+    >[];
 
     if (!Array.isArray(arrayData) || arrayData.length === 0) {
       console.log(`[AutoFill] No data for field array: ${question.id}`);
@@ -182,13 +185,13 @@ export class AutoFillEngine {
 
     // 新しいエントリを追加
     const newEntries = arrayData.map((entry) => {
-      const entryData: Record<string, any> = {};
+      const entryData: Record<string, unknown> = {};
 
       // 各フィールドを処理
       if (question.fields) {
         question.fields.forEach((field) => {
           const fieldMapping = field.mapping || "";
-          let value: any = undefined;
+          let value: unknown = undefined;
 
           // マッピングに基づいて値を取得
           if (fieldMapping && entry[fieldMapping] !== undefined) {
@@ -221,7 +224,10 @@ export class AutoFillEngine {
   /**
    * 条件を評価
    */
-  private evaluateCondition(condition: any, values: any): boolean {
+  private evaluateCondition(
+    condition: NonNullable<FlexibleQuestion["condition"]>,
+    values: FieldValues,
+  ): boolean {
     const fieldValue = _.get(values, condition.field);
     const operator = condition.operator || "===";
 

--- a/app/src/libs/devUtils/autoFill/useAutoFill.ts
+++ b/app/src/libs/devUtils/autoFill/useAutoFill.ts
@@ -21,7 +21,7 @@ interface UseAutoFillReturn {
  * 自動入力機能のフック
  */
 export function useAutoFill(
-  form: UseFormReturn<any>,
+  form: UseFormReturn,
   steps: readonly StepData[],
 ): UseAutoFillReturn {
   const [isEnabled, setIsEnabled] = useState(false);

--- a/app/src/libs/formUtils/formSchemaGenerator.ts
+++ b/app/src/libs/formUtils/formSchemaGenerator.ts
@@ -1,21 +1,21 @@
 import _ from "lodash";
 import { z } from "zod";
 
-import { QuestionsData } from "@/schema/hearingFormSchema";
+import { FlexibleQuestion, QuestionsData } from "@/schema/hearingFormSchema";
 
 export const generateZodSchema = (steps: QuestionsData) => {
   const schemaShape: z.ZodRawShape = {};
 
   steps.forEach((step) => {
     step.questions.forEach((q) => {
-      _.set(schemaShape, q.id, createZodField(q as any));
+      _.set(schemaShape, q.id, createZodField(q as FlexibleQuestion));
     });
   });
 
   return z.object(schemaShape);
 };
 
-function createZodField(field: any): z.ZodTypeAny {
+function createZodField(field: FlexibleQuestion): z.ZodTypeAny {
   let schema: z.ZodTypeAny;
 
   switch (field.type) {
@@ -28,7 +28,7 @@ function createZodField(field: any): z.ZodTypeAny {
 
     case "field_array":
       const itemShape: z.ZodRawShape = {};
-      (field.fields ?? []).forEach((f: any) => {
+      (field.fields ?? []).forEach((f: FlexibleQuestion) => {
         _.set(itemShape, f.id, createZodField(f));
       });
       schema = z.array(z.object(itemShape));
@@ -42,13 +42,16 @@ function createZodField(field: any): z.ZodTypeAny {
   const isOptional = !field.required || !!field.condition;
   if (isOptional) {
     if (field.type === "field_array") {
-      schema = (schema as z.ZodArray<any>).default([]);
+      schema = (schema as z.ZodArray<z.ZodTypeAny>).default([]);
     } else {
       schema = schema.optional().or(z.literal(""));
     }
   } else {
     if (field.type === "field_array") {
-      schema = (schema as z.ZodArray<any>).min(1, "1つ以上入力が必要です");
+      schema = (schema as z.ZodArray<z.ZodTypeAny>).min(
+        1,
+        "1つ以上入力が必要です",
+      );
     } else if (field.type !== "number") {
       schema = (schema as z.ZodString).min(1, "必須項目です");
     }

--- a/app/src/libs/hearing/hearingJsonBuilder.ts
+++ b/app/src/libs/hearing/hearingJsonBuilder.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import z from "zod";
 
 import {
   HearingJsonInput,
@@ -182,12 +183,12 @@ export function validateHearingJson(hearingJson: HearingJsonInput): {
   try {
     const validated = hearingJsonSchema.parse(hearingJson);
     return { success: true, data: validated };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("[HearingJsonBuilder] Validation failed:", error);
 
     // Zodエラーの場合、詳細な情報を抽出
-    if (error?.issues) {
-      const errorMessages = error.issues.map((issue: any) => {
+    if (error instanceof z.ZodError) {
+      const errorMessages = error.issues.map((issue) => {
         const path = issue.path.join(".");
         return `${path}: ${issue.message}`;
       });


### PR DESCRIPTION
## Summary
- `route.ts`: 未使用変数 `aijsonResponse` の代入を削除
- `useAdditionalQuestions.ts`: 意図的な依存配列省略に `eslint-disable-next-line` を追加
- `additional-questions/page.tsx`: `form.watch()` を React Compiler 互換の `useWatch()` に置換
- `autoFillEngine.ts`, `useAutoFill.ts`: `UseFormReturn<any>` → `UseFormReturn`、`any` → 適切な型に修正（11件）
- `formSchemaGenerator.ts`: `any` → `FlexibleQuestion` / `z.ZodArray<z.ZodTypeAny>` に修正（5件）
- `hearingJsonBuilder.ts`: `error: any` → `error: unknown` + `instanceof z.ZodError` で型安全化（2件）

## Test plan
- [x] `npm run lint` で対象ファイルの warning が 0 件であることを確認
- [ ] 残りの warning は `features/lifePlan/calculators/` 配下の6件のみ（対象外）
- [ ] ヒアリングフォームの自動入力機能が正常動作すること
- [ ] 追加質問ページのボタンラベル切り替えが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)