### PR TITLE
fix: ヒアリングのステップ切り替え時にページ上部へスクロール

### DIFF
--- a/app/src/app/hearing/page.tsx
+++ b/app/src/app/hearing/page.tsx
@@ -80,6 +80,7 @@ export default function LifePlanStepForm() {
 
     if (isValid) {
       setCurrentStep((prev) => prev + 1);
+      window.scrollTo({ top: 0, behavior: "smooth" });
     } else {
       console.log("エラー中のフィールド:", initialForm.formState.errors);
     }
@@ -278,7 +279,10 @@ export default function LifePlanStepForm() {
               <Button
                 type="button"
                 variant="ghost"
-                onClick={() => setCurrentStep((s) => s - 1)}
+                onClick={() => {
+                  setCurrentStep((s) => s - 1);
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                }}
                 disabled={currentStep === 0}
               >
                 戻る


### PR DESCRIPTION
## 📝 対応Issue
- なし

## 🚀 実装内容
- ヒアリングページで「次へ進む」「戻る」ボタン押下時に `window.scrollTo({ top: 0, behavior: "smooth" })` を呼び出し、ページ上部にスムーズスクロールするよう修正

## 🧪 動作確認
- [ ] ヒアリングページで「次へ進む」ボタンを押した際にページ上部にスクロールすること
- [ ] 「戻る」ボタンを押した際にもページ上部にスクロールすること

## 📸 キャプチャ
- なし

## ➕ 備考
- `behavior: "smooth"` でスムーズなスクロールアニメーション付き

🤖 Generated with [Claude Code](https://claude.com/claude-code)