### PR TITLE
202 - add past and future year range

### DIFF
--- a/app/src/components/hearingForm/DynamicOptions.tsx
+++ b/app/src/components/hearingForm/DynamicOptions.tsx
@@ -24,6 +24,29 @@ export function DynamicOptions({
         </>
       );
 
+    // 1.5. 過去〜未来の年（子どもの誕生年など：100年前〜20年先）
+    case "past_and_future_year_range":
+      return (
+        <>
+          {Array.from({ length: 20 }, (_, i) => {
+            const year = currentYear + 20 - i;
+            return (
+              <SelectItem key={year} value={year.toString()}>
+                {year}年
+              </SelectItem>
+            );
+          })}
+          {Array.from({ length: 100 }, (_, i) => {
+            const year = currentYear - i;
+            return (
+              <SelectItem key={year} value={year.toString()}>
+                {year}年
+              </SelectItem>
+            );
+          })}
+        </>
+      );
+
     // 2. 現在〜未来の年（ライフイベント、完済予定など：50年先まで）
     case "future_year_range":
       return (

--- a/app/src/consts/questions.ts
+++ b/app/src/consts/questions.ts
@@ -59,7 +59,7 @@ export const QUESTIONS = [
             id: "q07",
             label: "誕生年",
             type: "select",
-            options: "year_range",
+            options: "past_and_future_year_range",
             required: true,
             mapping: "birthYear",
             defaultValue: "2020",

--- a/app/src/libs/devUtils/autoFill/fieldFillers.ts
+++ b/app/src/libs/devUtils/autoFill/fieldFillers.ts
@@ -280,6 +280,11 @@ export class FieldFiller {
       return (currentYear + 5).toString(); // 5年後
     }
 
+    // 年範囲（子どもの誕生年など）
+    if (q.options === "past_and_future_year_range") {
+      return "2020";
+    }
+
     // 年範囲（保険加入年等）
     if (q.options === "year_range") {
       return "2020";

--- a/app/src/libs/devUtils/autoFill/optionsResolver.ts
+++ b/app/src/libs/devUtils/autoFill/optionsResolver.ts
@@ -30,6 +30,16 @@ export function resolveOptions(options: unknown): Option[] {
         return { label: `${year}年`, value: year.toString() };
       });
 
+    case "past_and_future_year_range":
+      // 1950年〜現在+20年（子どもの誕生年など）
+      return Array.from(
+        { length: currentYear + 20 - 1949 },
+        (_, i) => {
+          const year = 1950 + i;
+          return { label: `${year}年`, value: year.toString() };
+        },
+      );
+
     case "future_year_range":
       // 現在〜2100年までの年
       return Array.from({ length: 2100 - currentYear + 1 }, (_, i) => {


### PR DESCRIPTION

  📝 対応Issue

  - Fixes #202

  🚀 実装内容

  - 子どもの誕生年セレクトで未来の年も選択可能に
    - 新しい動的オプション past_and_future_year_range（過去100年〜未来20年）を DynamicOptions.tsx
  に追加
    - 子どもの誕生年（q07）の options を year_range → past_and_future_year_range
  に変更（questions.ts）
    - autoFill 用のオプション解決ロジックを optionsResolver.ts に追加
    - autoFill 用のデフォルト値を fieldFillers.ts に追加
  - 出産予定の子どもの誕生年を入力できるように対応（質問ラベルが「お子様がいらっしゃいますか？（予定がある）」のため）

  🧪 動作確認

  - 子どもの誕生年セレクトで未来の年（〜20年先）が選択できること
  - 子どもの誕生年セレクトで過去の年（〜100年前）も引き続き選択できること
  - 本人・配偶者の誕生年は従来通り過去のみ（year_range）であること
  - autoFill でフォームが正しく自動入力されること

  📸 キャプチャ

  - なし

  ➕ 備考

  - 本人・配偶者の誕生年（q02, q04）は過去のみの year_range のまま変更なし
  - セレクトの並び順は未来年（降順）→ 現在年（降順）で、直近の年が選びやすい配置